### PR TITLE
fix: 修复主动消息提前触发与时间点错乱问题

### DIFF
--- a/core/chat_flow.py
+++ b/core/chat_flow.py
@@ -82,7 +82,10 @@ class ProactiveCoreMixin:
             logger.error(f"[主动消息] 存档对话历史失败喵: {e}")
             logger.warning("[主动消息] 对话存档失败喵，但会继续执行后续步骤喵。")
 
-        parsed = self._parse_session_id(session_id)
+        # 提前规范化：session_data 写入与 scheduler job 必须使用同一个 key，
+        # 否则 check_and_chat 用 normalized key 读 unanswered_count 时永远得到 0。
+        normalized_session_id = self._normalize_session_id(session_id)
+        parsed = self._parse_session_id(normalized_session_id)
         is_private_session = parsed and (
             "Friend" in parsed[1] or "Private" in parsed[1]
         )
@@ -93,16 +96,16 @@ class ProactiveCoreMixin:
             # 更新未回复计数器
             # 每次主动发送成功后，未回复次数 +1
             new_unanswered_count = unanswered_count + 1
-            self.session_data.setdefault(session_id, {})["unanswered_count"] = (
+            self.session_data.setdefault(normalized_session_id, {})["unanswered_count"] = (
                 new_unanswered_count
             )
             logger.info(
-                f"[主动消息] {self._get_session_log_str(session_id)} 的第 {new_unanswered_count} 次主动消息已发送完成，当前未回复次数: {new_unanswered_count} 次喵。"
+                f"[主动消息] {self._get_session_log_str(normalized_session_id)} 的第 {new_unanswered_count} 次主动消息已发送完成，当前未回复次数: {new_unanswered_count} 次喵。"
             )
 
             # 私聊任务：锁内仅计算调度参数并写入持久化字段，避免在持锁期间操作调度器。
             if is_private_session:
-                session_config = self._get_session_config(session_id)
+                session_config = self._get_session_config(normalized_session_id)
                 if not session_config:
                     return
 
@@ -118,7 +121,7 @@ class ProactiveCoreMixin:
                 next_trigger_time = scheduled_at + random_interval
                 run_date = datetime.fromtimestamp(next_trigger_time, tz=self.timezone)
 
-                session_payload = self.session_data.setdefault(session_id, {})
+                session_payload = self.session_data.setdefault(normalized_session_id, {})
                 session_payload["next_trigger_time"] = next_trigger_time
                 session_payload["last_scheduled_at"] = scheduled_at
                 session_payload["last_schedule_min_interval_seconds"] = min_interval
@@ -136,7 +139,6 @@ class ProactiveCoreMixin:
         if scheduled_job_payload is not None:
             # 统一用规范化 ID 作为 job id 与 args，并先清理同目标历史任务，
             # 避免因 session_id 前缀漂移（如 default: 与 test:）产生无法被用户回复取消的幽灵任务。
-            normalized_session_id = self._normalize_session_id(session_id)
             self._purge_related_jobs(normalized_session_id)
             self.scheduler.add_job(
                 self.check_and_chat,

--- a/core/chat_flow.py
+++ b/core/chat_flow.py
@@ -134,12 +134,16 @@ class ProactiveCoreMixin:
             await self._save_data_internal()
 
         if scheduled_job_payload is not None:
+            # 统一用规范化 ID 作为 job id 与 args，并先清理同目标历史任务，
+            # 避免因 session_id 前缀漂移（如 default: 与 test:）产生无法被用户回复取消的幽灵任务。
+            normalized_session_id = self._normalize_session_id(session_id)
+            self._purge_related_jobs(normalized_session_id)
             self.scheduler.add_job(
                 self.check_and_chat,
                 "date",
                 run_date=scheduled_job_payload["run_date"],
-                args=[session_id],
-                id=session_id,
+                args=[normalized_session_id],
+                id=normalized_session_id,
                 replace_existing=True,
                 misfire_grace_time=60,
             )
@@ -178,6 +182,21 @@ class ProactiveCoreMixin:
                 return
 
             schedule_conf = session_config.get("schedule_settings", {})
+
+            # 二次校验：距上次用户消息若未满最小间隔，则跳过并重排。
+            # 兜底拦截任何因幽灵任务/调度器残留导致的提早触发，使 min_interval 始终生效。
+            # 暂时注释：先单独验证调度器关闭与 job id 统一两处修复是否生效，避免兜底逻辑掩盖问题。
+            # last_msg_time = self.last_message_times.get(normalized_session_id, 0)
+            # if last_msg_time > 0:
+            #     elapsed = time.time() - last_msg_time
+            #     min_interval_sec = int(schedule_conf.get("min_interval_minutes", 0)) * 60
+            #     if min_interval_sec > 0 and elapsed < min_interval_sec:
+            #         logger.info(
+            #             f"[主动消息] {self._get_session_log_str(normalized_session_id, session_config)} "
+            #             f"距上次用户消息仅 {elapsed:.0f} 秒，未满最小间隔 {min_interval_sec} 秒，跳过并重新调度喵。"
+            #         )
+            #         await self._schedule_next_chat_and_save(normalized_session_id)
+            #         return
 
             # 未回复次数上限检查
             async with self.data_lock:

--- a/core/chat_flow.py
+++ b/core/chat_flow.py
@@ -137,20 +137,9 @@ class ProactiveCoreMixin:
             await self._save_data_internal()
 
         if scheduled_job_payload is not None:
-            # 统一用规范化 ID 作为 job id 与 args，并先清理同目标历史任务，
-            # 避免因 session_id 前缀漂移（如 default: 与 test:）产生无法被用户回复取消的幽灵任务。
-            self._purge_related_jobs(normalized_session_id)
-            self.scheduler.add_job(
-                self.check_and_chat,
-                "date",
-                run_date=scheduled_job_payload["run_date"],
-                args=[normalized_session_id],
-                id=normalized_session_id,
-                replace_existing=True,
-                misfire_grace_time=60,
-            )
+            self._add_chat_job(normalized_session_id, scheduled_job_payload["run_date"])
             logger.info(
-                f"[主动消息] 已为 {self._get_session_log_str(session_id, scheduled_job_payload['session_config'])} 安排下一次主动消息喵，时间：{scheduled_job_payload['run_date'].strftime('%Y-%m-%d %H:%M:%S')} 喵。"
+                f"[主动消息] 已为 {self._get_session_log_str(normalized_session_id, scheduled_job_payload['session_config'])} 安排下一次主动消息喵，时间：{scheduled_job_payload['run_date'].strftime('%Y-%m-%d %H:%M:%S')} 喵。"
             )
 
     async def check_and_chat(self, session_id: str) -> None:

--- a/core/chat_flow.py
+++ b/core/chat_flow.py
@@ -185,20 +185,6 @@ class ProactiveCoreMixin:
 
             schedule_conf = session_config.get("schedule_settings", {})
 
-            # 二次校验：距上次用户消息若未满最小间隔，则跳过并重排。
-            # 兜底拦截任何因幽灵任务/调度器残留导致的提早触发，使 min_interval 始终生效。
-            # 暂时注释：先单独验证调度器关闭与 job id 统一两处修复是否生效，避免兜底逻辑掩盖问题。
-            # last_msg_time = self.last_message_times.get(normalized_session_id, 0)
-            # if last_msg_time > 0:
-            #     elapsed = time.time() - last_msg_time
-            #     min_interval_sec = int(schedule_conf.get("min_interval_minutes", 0)) * 60
-            #     if min_interval_sec > 0 and elapsed < min_interval_sec:
-            #         logger.info(
-            #             f"[主动消息] {self._get_session_log_str(normalized_session_id, session_config)} "
-            #             f"距上次用户消息仅 {elapsed:.0f} 秒，未满最小间隔 {min_interval_sec} 秒，跳过并重新调度喵。"
-            #         )
-            #         await self._schedule_next_chat_and_save(normalized_session_id)
-            #         return
 
             # 未回复次数上限检查
             async with self.data_lock:

--- a/core/plugin_lifecycle.py
+++ b/core/plugin_lifecycle.py
@@ -152,6 +152,22 @@ class LifecycleMixin:
     async def terminate(self) -> None:
         """插件被卸载或停用时调用的清理函数。"""
         logger.info("[主动消息] 收到插件终止指令，开始清理资源喵。")
+        # 调度器关闭优先于其它清理：必须最先、且独立 try 执行，
+        # 避免遥测/计时器等任意一步抛异常时跳过 shutdown，导致旧 scheduler 残留在后台继续触发任务。
+        if getattr(self, "scheduler", None) and self.scheduler.running:
+            try:
+                jobs = self.scheduler.get_jobs()
+                logger.info(f"[主动消息] 正在清理调度器任务喵，数量: {len(jobs)}")
+                for job in jobs:
+                    try:
+                        self.scheduler.remove_job(job.id)
+                        logger.debug(f"[主动消息] 已移除调度器任务喵: {job.id}")
+                    except Exception as e:
+                        logger.warning(f"[主动消息] 移除调度器任务时出错喵: {e}")
+                self.scheduler.shutdown(wait=False)
+                logger.info("[主动消息] 调度器已关闭喵。")
+            except Exception as e:
+                logger.error(f"[主动消息] 关闭调度器时出错喵: {e}")
         try:
             if self._heartbeat_task:
                 self._heartbeat_task.cancel()
@@ -210,23 +226,6 @@ class LifecycleMixin:
 
             self.auto_trigger_timers.clear()
             logger.info(f"[主动消息] 已取消 {auto_trigger_count} 个自动触发计时器喵。")
-
-            # 清理调度器任务（逐个移除后再 shutdown，便于日志定位）
-            if self.scheduler and self.scheduler.running:
-                try:
-                    jobs = self.scheduler.get_jobs()
-                    logger.info(f"[主动消息] 正在清理调度器任务喵，数量: {len(jobs)}")
-                    for job in jobs:
-                        try:
-                            self.scheduler.remove_job(job.id)
-                            logger.debug(f"[主动消息] 已移除调度器任务喵: {job.id}")
-                        except Exception as e:
-                            logger.warning(f"[主动消息] 移除调度器任务时出错喵: {e}")
-
-                    self.scheduler.shutdown()
-                    logger.info("[主动消息] 调度器已关闭喵。")
-                except Exception as e:
-                    logger.error(f"[主动消息] 关闭调度器时出错喵: {e}")
 
             # 终止前最后一次持久化，尽量保留当前会话状态
             if self.data_lock:

--- a/core/task_scheduler.py
+++ b/core/task_scheduler.py
@@ -627,12 +627,14 @@ class SchedulerMixin:
                     random_interval
                 )
 
+                normalized_for_job = self._normalize_session_id(session_id)
+                self._purge_related_jobs(normalized_for_job)
                 self.scheduler.add_job(
                     self.check_and_chat,
                     "date",
                     run_date=run_date,
-                    args=[session_id],
-                    id=session_id,
+                    args=[normalized_for_job],
+                    id=normalized_for_job,
                     replace_existing=True,
                     misfire_grace_time=60,
                 )

--- a/core/task_scheduler.py
+++ b/core/task_scheduler.py
@@ -191,6 +191,20 @@ class SchedulerMixin:
                 except Exception:
                     pass
 
+    def _add_chat_job(self, session_id: str, run_date: datetime) -> None:
+        """规范化 session_id，清理同目标历史任务，并注册一个新的 check_and_chat 定时 job。"""
+        normalized = self._normalize_session_id(session_id)
+        self._purge_related_jobs(normalized)
+        self.scheduler.add_job(
+            self.check_and_chat,
+            "date",
+            run_date=run_date,
+            args=[normalized],
+            id=normalized,
+            replace_existing=True,
+            misfire_grace_time=60,
+        )
+
     def _has_related_persisted_task(self, session_id: str) -> bool:
         """判断同一目标是否存在仍可恢复的持久化任务（避免重复触发）。"""
         parsed = self._parse_session_id(session_id)
@@ -429,15 +443,7 @@ class SchedulerMixin:
                     )
                     continue
 
-                self.scheduler.add_job(
-                    self.check_and_chat,
-                    "date",
-                    run_date=run_date,
-                    args=[session_id],
-                    id=session_id,
-                    replace_existing=True,
-                    misfire_grace_time=60,
-                )
+                self._add_chat_job(session_id, run_date)
                 logger.info(
                     f"[主动消息] 已成功从文件恢复任务喵: {self._get_session_log_str(session_id, session_config)}, 执行时间: {run_date} 喵"
                 )
@@ -511,16 +517,7 @@ class SchedulerMixin:
 
             # 更新调度器与持久化数据
             # 先清理同目标历史任务，再写入新任务，确保同一目标仅一条生效
-            self._purge_related_jobs(normalized_session_id)
-            self.scheduler.add_job(
-                self.check_and_chat,
-                "date",
-                run_date=run_date,
-                args=[normalized_session_id],
-                id=normalized_session_id,
-                replace_existing=True,
-                misfire_grace_time=60,
-            )
+            self._add_chat_job(normalized_session_id, run_date)
 
             session_payload = self.session_data.setdefault(normalized_session_id, {})
             session_payload["next_trigger_time"] = next_trigger_time
@@ -619,7 +616,8 @@ class SchedulerMixin:
 
                 # 自动触发生成的任务虽然不持久化到磁盘，但仍需补齐运行时元信息，
                 # 以便 Web 管理端能够正确计算倒计时进度，而不是误判为满进度。
-                session_payload = self.session_data.setdefault(session_id, {})
+                normalized_for_job = self._normalize_session_id(session_id)
+                session_payload = self.session_data.setdefault(normalized_for_job, {})
                 session_payload["last_scheduled_at"] = scheduled_at
                 session_payload["last_schedule_min_interval_seconds"] = min_interval
                 session_payload["last_schedule_max_interval_seconds"] = max_interval
@@ -627,17 +625,7 @@ class SchedulerMixin:
                     random_interval
                 )
 
-                normalized_for_job = self._normalize_session_id(session_id)
-                self._purge_related_jobs(normalized_for_job)
-                self.scheduler.add_job(
-                    self.check_and_chat,
-                    "date",
-                    run_date=run_date,
-                    args=[normalized_for_job],
-                    id=normalized_for_job,
-                    replace_existing=True,
-                    misfire_grace_time=60,
-                )
+                self._add_chat_job(normalized_for_job, run_date)
 
                 logger.info(
                     f"[主动消息] {self._get_session_log_str(session_id, current_config)} 满足条件，自动触发任务已创建喵！执行时间 (非持久化): {run_date.strftime('%Y-%m-%d %H:%M:%S')} 喵"

--- a/main.py
+++ b/main.py
@@ -90,6 +90,9 @@ class ProactiveChatPlugin(
         self._start_time: float = 0.0
         # 保存原 asyncio 全局异常处理器，以便插件卸载时恢复原状。
         self._original_exception_handler = None
+        # 标记是否接管过全局异常处理器；必须在 __init__ 初始化，
+        # 否则遥测关闭时 terminate 访问该属性会抛 AttributeError，导致后续清理（含调度器关闭）全部中断。
+        self._exception_handler_installed = False
 
         # 群聊沉默倒计时与自动触发计时器
         self.group_timers: dict[str, asyncio.TimerHandle] = {}


### PR DESCRIPTION
## 📝 描述 / Description

修复主动消息调度器因插件重载时未正确关闭而残留在进程中，导致多个调度器实例并发运行、主动消息按错误时间点触发的问题。同时修复因 `session_id` 前缀漂移产生的幽灵任务无法被用户回复取消的问题。

Fixes a bug where the plugin's `AsyncIOScheduler` instance was not shut down during plugin reload (due to an `AttributeError` in `terminate()`), causing multiple scheduler instances to coexist in the same process and fire jobs at stale/incorrect times. Also fixes ghost jobs created with a mismatched `session_id` prefix that could not be cancelled by incoming user messages.

## 🛠️ 改动点 / Modifications

**根因一：`terminate()` 因访问未初始化属性提前崩溃，调度器未关闭**

- `_exception_handler_installed` 仅在遥测启用时赋值，遥测关闭时 `terminate()` 访问该属性抛 `AttributeError`，后续所有清理（含 `scheduler.shutdown()`）全部跳过。每次 reload 旧调度器残留在事件循环中，带着旧 job 继续按旧时间点触发。
- `main.py`：在 `__init__` 初始化 `_exception_handler_installed = False`，消除崩溃根源。
- `core/plugin_lifecycle.py`：将 `scheduler.shutdown()` 提前至 `terminate()` 最开头并独立 `try` 包裹，保证不被其它清理步骤的异常连累。

**根因二：`_finalize_and_reschedule` 建 job 时 `session_id` 前缀可能漂移，且 `session_data` 与 job 使用不同 key**

- 该函数用 raw `session_id` 作为 job id（可能为 `default:` 前缀），而用户回复时 `on_friend_message` 用 `normalized_session_id` 删 job，两者不一致导致幽灵任务无法被取消。
- 同时，函数在锁内用 raw `session_id` 写 `session_data`（含 `unanswered_count`），但 job 注册为 normalized key，导致 `check_and_chat` 下次触发时读到的 `unanswered_count` 永远为 0，`max_unanswered_times` 限制完全失效。
- `core/chat_flow.py`：函数入口提前规范化 `session_id`，锁内所有 `session_data` 写入与 job 注册统一使用 `normalized_session_id`，并在建 job 前调用 `_purge_related_jobs` 清理同目标历史任务。

**根因三：`_handle_auto_trigger_callback` 存在与根因二相同的 job id 漂移问题**

- `core/task_scheduler.py`：auto_trigger 路径的 `add_job` 前同样加 normalize + `_purge_related_jobs`，job id 和 args 统一使用 `normalized_session_id`。

- [x] 这**不是**一个破坏性变更 / This is NOT a breaking change.

## 📸 运行截图或测试结果 / Screenshots or Test Results

**重载后正常启动日志（调度器干净，0 个幽灵任务恢复）：**

```
[core.task_scheduler:459]: [主动消息] 任务恢复检查完成，共恢复 0 个定时任务喵。
[core.plugin_lifecycle:113]: [主动消息] 调度器已初始化喵。
[core.task_scheduler:365]: [主动消息] 已为 私聊 xxxx 设置自动触发器喵，将在 5 分钟后检查是否需要自动触发喵。
[core.task_scheduler:311]: [主动消息] 已为 1 个会话设置自动主动消息触发器喵。（跳过：已有任务 0，无效 0，未启用 0，已达未回复上限 0）
```

修复后实测：控制台打印的"下次发送时间"与实际触发时间一致，用户回复后主动消息不再提前触发。

## ✅ 检查清单 / Checklist

- [x] 😊 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。/ If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
- [x] 👀 我的更改经过了良好的测试，**并已在上方提供了"运行截图"或"测试日志"**。/ My changes have been well-tested, **and "Screenshots" or "Test Logs" have been provided above**.
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 文件中。/ I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to `requirements.txt`.
- [x] 😮 我的更改没有引入恶意代码。/ My changes do not introduce malicious code.

## ❤️ CONTRIBUTING

- [x] 🥳 我已阅读并同意遵守该项目的 [贡献指南](https://github.com/DBJD-CR/astrbot_plugin_proactive_chat/blob/main/CONTRIBUTING.md) / I have read and agree to abide by the [CONTRIBUTING](https://github.com/DBJD-CR/astrbot_plugin_proactive_chat/blob/main/CONTRIBUTING.md) of this project.

## Summary by Sourcery

修复由于残留的调度器和不一致的会话标识符导致的主动消息调度问题，确保任务能够在正确的时间被调度、取消和触发。

Bug 修复：
- 确保插件调度器在终止时总能被干净地关闭，这样在重新加载实例时不会留下仍在运行、且触发时间已过期的旧任务。
- 在更新会话状态和调度任务时一致地规范化会话标识符，防止产生无法通过用户回复取消的“幽灵任务”。
- 使自动触发任务的创建与规范化后的会话 ID 对齐，并清理相关的历史任务，以避免重复或提前触发。
- 通过在插件构造期间初始化异常处理器安装标志，防止在终止时出现 AttributeError，从而确保清理逻辑总能执行。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix proactive message scheduling issues caused by leftover schedulers and inconsistent session identifiers, ensuring jobs are scheduled, cancelled, and triggered at the correct times.

Bug Fixes:
- Ensure the plugin scheduler is always shut down cleanly on termination so reloaded instances do not leave old jobs running with stale trigger times.
- Normalize session identifiers consistently when updating session state and scheduling jobs to prevent ghost jobs that cannot be cancelled by user replies.
- Align auto-trigger job creation with normalized session IDs and purge related historical jobs to avoid duplicated or early triggers.
- Prevent AttributeError on terminate by initializing the exception handler installation flag during plugin construction so cleanup logic always runs.

</details>

## 由 Sourcery 提供的摘要

通过规范会话标识符并以更健壮的方式关闭调度器，确保在插件重载期间，主动消息任务能够被可靠地调度和清理。

错误修复：
- 在调度、重新调度以及跟踪主动聊天任务时，一致地规范会话标识符，避免“幽灵”任务和错误的计数器。
- 将聊天任务的创建集中到一个辅助方法中，在添加新任务前清理相关的历史任务，确保每个会话只存在一个有效任务。
- 修复自动触发调度逻辑，对内存中的元数据和已调度任务都使用规范化的会话 ID，使用户回复可以正确地取消这些任务。
- 在构造函数中初始化异常处理器安装标志，并在插件终止时优先执行调度器关闭逻辑，防止由于 AttributeError 导致跳过清理，从而留下仍在运行的陈旧任务。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure proactive message tasks are scheduled and cleaned up reliably across plugin reloads by normalizing session identifiers and shutting down the scheduler robustly.

Bug Fixes:
- Normalize session identifiers consistently when scheduling, rescheduling, and tracking proactive chat jobs to avoid ghost tasks and incorrect counters.
- Centralize chat job creation into a helper that purges related historical jobs before adding a new one, ensuring only one valid job exists per session.
- Fix automatic-trigger scheduling to use normalized session IDs for both in-memory metadata and scheduled jobs so user replies can correctly cancel them.
- Initialize the exception handler installation flag at construction time and make scheduler shutdown run first in plugin termination to prevent AttributeError from skipping cleanup and leaving stale jobs running.

</details>