### PR TITLE
fix: 修复 README 中失效的 Star History 图表

### DIFF
--- a/README.md
+++ b/README.md
@@ -1736,4 +1736,4 @@ GNU Affero General Public License v3.0 - 详见 [LICENSE](LICENSE) 文件。
 
 ## <span id="star">⭐️ 星星</span>
 
-[![Star History Chart](https://api.star-history.com/svg?repos=DBJD-CR/astrbot_plugin_proactive_chat&type=Date)](https://www.star-history.com/#DBJD-CR/astrbot_plugin_proactive_chat&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=DBJD-CR/astrbot_plugin_proactive_chat&type=Date)](https://star-history.dera.page/#DBJD-CR/astrbot_plugin_proactive_chat&Date)

--- a/README_EN.md
+++ b/README_EN.md
@@ -1736,4 +1736,4 @@ This plugin is licensed under AGPL v3.0, which means:
 
 ## <span id="star">⭐️ Stars</span>
 
-[![Star History Chart](https://api.star-history.com/svg?repos=DBJD-CR/astrbot_plugin_proactive_chat&type=Date)](https://www.star-history.com/#DBJD-CR/astrbot_plugin_proactive_chat&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=DBJD-CR/astrbot_plugin_proactive_chat&type=Date)](https://star-history.dera.page/#DBJD-CR/astrbot_plugin_proactive_chat&Date)

--- a/README_JP.md
+++ b/README_JP.md
@@ -1738,4 +1738,4 @@ GNU Affero General Public License v3.0 — 詳細は [LICENSE](LICENSE) を参�
 
 ## <span id="star">⭐️ Star</span>
 
-[![Star History Chart](https://api.star-history.com/svg?repos=DBJD-CR/astrbot_plugin_proactive_chat&type=Date)](https://www.star-history.com/#DBJD-CR/astrbot_plugin_proactive_chat&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=DBJD-CR/astrbot_plugin_proactive_chat&type=Date)](https://star-history.dera.page/#DBJD-CR/astrbot_plugin_proactive_chat&Date)


### PR DESCRIPTION
修复 README 中失效的 Star History 图表。

由于 GitHub stargazer 接口限制，现有图表已无法正常加载。本次将图表地址切换到新的可用服务，并同步更新 README.md、README_EN.md、README_JP.md 三份文档，恢复星标走势图的正常展示。

## Summary by Sourcery

将 README 中的 Star History 图表切换至可用服务以恢复星标趋势展示。

Bug Fixes:
- 修复中文、英文和日文 README 中失效的 Star History 图表链接，恢复星标趋势图正常展示。

Documentation:
- 更新三份 README 的 Star History 图表服务地址。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

将 README 中的 Star History 图表切换至可用服务以恢复星标趋势展示。

Bug Fixes:
- 修复中文、英文和日文 README 中失效的 Star History 图表链接，恢复星标趋势图正常展示。

Documentation:
- 更新三份 README 的 Star History 图表服务地址。

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **文档**
  * 更新中文、英文和日文 README 中的 Star History 图表链接。
  * 图表内容及关联仓库保持不变。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->